### PR TITLE
[findtakeovers.sh] Add WP.com asset takeover string

### DIFF
--- a/findtakeovers.sh
+++ b/findtakeovers.sh
@@ -12,6 +12,7 @@ searches=(
     "project not found"
     "Your CNAME settings"
     "The resource that you are attempting to access does not exist or you don't have the necessary permissions to view it."
+    "Domain mapping upgrade for this domain not found"
 )
 
 for str in "${searches[@]}"; do


### PR DESCRIPTION
Great work @EdOverflow! Here's another string for `findtakeovers.sh` focusing on WordPress.com sites: `"Domain mapping upgrade for this domain not found"`

(e.g. H1 report [https://hackerone.com/reports/274336](#274336) and this [screenshot](https://twitter.com/SecurityYasin/status/916248081494171648))