### PR TITLE
[findtakeovers.sh] Add FeedPress and UserVoice strings

### DIFF
--- a/findtakeovers.sh
+++ b/findtakeovers.sh
@@ -14,7 +14,6 @@ searches=(
     "The resource that you are attempting to access does not exist or you don't have the necessary permissions to view it."
     "Domain mapping upgrade for this domain not found"
     "The feed has not been found"
-    "The requested URL / was not found on this server."
     "This UserVoice subdomain is currently available!"
 )
 

--- a/findtakeovers.sh
+++ b/findtakeovers.sh
@@ -13,6 +13,9 @@ searches=(
     "Your CNAME settings"
     "The resource that you are attempting to access does not exist or you don't have the necessary permissions to view it."
     "Domain mapping upgrade for this domain not found"
+    "The feed has not been found"
+    "The requested URL / was not found on this server."
+    "This UserVoice subdomain is currently available!"
 )
 
 for str in "${searches[@]}"; do


### PR DESCRIPTION
* **FeedPress** (podcast analytics platform)
    * `The feed has not been found`
    * e.g. https://hackerone.com/reports/195350
* ~**Unbounce** (landing and conversion page platform)~
    * ~`The requested URL / was not found on this server.`~
    * ~Depends on CNAME configuration (sometimes pages may be hosted in subdirectories)~
* **UserVoice** (customer support sites)
    * `This UserVoice subdomain is currently available!`
    * e.g. 1: https://hackerone.com/reports/269109
    * e.g. 2: https://hackerone.com/reports/142096