### PR TITLE
Dockerized Megplus | GLHF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:16.04
+LABEL maintainer="Anshuman Bhartiya"
+
+RUN apt-get update
+
+RUN apt-get install -y libldns-dev git build-essential wget libglib2.0-dev php7.0
+
+RUN wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz && \
+    tar xvf go1.9.2.linux-amd64.tar.gz && \
+    mv go /usr/local
+
+ENV GOPATH "/root/work"
+ENV PATH "$PATH:/usr/local/go/bin:$GOPATH/bin"
+ENV GOBIN "$GOPATH/bin/"
+
+RUN go get github.com/tomnomnom/meg && go get github.com/tomnomnom/waybackurls
+
+RUN git clone https://github.com/anshumanbh/megplus.git
+
+WORKDIR /megplus
+
+ENTRYPOINT ["./megplus.sh"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Example: ./megplus.sh domains
 Example: ./megplus.sh -x XXXXXXXXXXXXXXXX
 ```
 
+## Usage - Docker
+
+If you don't feel like installing all the dependencies mentioned above, you can simply run the `abhartiya/tools_megplus` Docker container, where `test.txt` is a sample file containing the URLs to test against. In your case, this will be the file containing the URLs you want to test:
+
+`docker run -v $(pwd):/megplus abhartiya/tools_megplus test.txt`
+
+The command will run the `abhartiya/tools_megplus` Docker image as a container and mount the `pwd` onto the container as a volume (at `/megplus`), which makes the `test.txt` file available to the container. Once megplus finishes running, the `out` directory will be created in `pwd` with all the results.  
+
+
 ## Scanner
 
 meg+ will scan for the following things:

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+http://test.com/


### PR DESCRIPTION
I've built a Docker image and pushed it to my public repository here - https://hub.docker.com/r/abhartiya/tools_megplus/

So, anybody can just pull it and run megplus now without having to worry about the dependencies. 

In this PR, I am providing the Dockerfile that was used to build that image, updated the README and also provided a sample `test.txt` file to test against. 

Thanks again for giving back to the community!

Cheers! 